### PR TITLE
Member taints

### DIFF
--- a/lib/horde/dynamic_supervisor.ex
+++ b/lib/horde/dynamic_supervisor.ex
@@ -269,6 +269,11 @@ defmodule Horde.DynamicSupervisor do
   def taint(supervisor), do: call(supervisor, :taint)
 
   @doc """
+  Untaints the supervisor.
+  """
+  def untaint(supervisor), do: call(supervisor, :untaint)
+
+  @doc """
   Waits for Horde.DynamicSupervisor to have quorum.
   """
   @spec wait_for_quorum(horde :: GenServer.server(), timeout :: timeout()) :: :ok

--- a/lib/horde/dynamic_supervisor.ex
+++ b/lib/horde/dynamic_supervisor.ex
@@ -264,6 +264,11 @@ defmodule Horde.DynamicSupervisor do
   def count_children(supervisor), do: call(supervisor, :count_children)
 
   @doc """
+  Taints the supervisor, preventing any new processes from being started under it.
+  """
+  def taint(supervisor), do: call(supervisor, :taint)
+
+  @doc """
   Waits for Horde.DynamicSupervisor to have quorum.
   """
   @spec wait_for_quorum(horde :: GenServer.server(), timeout :: timeout()) :: :ok

--- a/lib/horde/dynamic_supervisor.ex
+++ b/lib/horde/dynamic_supervisor.ex
@@ -64,6 +64,7 @@ defmodule Horde.DynamicSupervisor do
           | {:members, [Horde.Cluster.member()] | :auto}
           | {:delta_crdt_options, [DeltaCrdt.crdt_option()]}
           | {:process_redistribution, :active | :passive}
+          | {:tainted, boolean()}
 
   @callback init(options()) :: {:ok, options()} | :ignore
   @callback child_spec(options :: options()) :: Supervisor.child_spec()
@@ -120,7 +121,8 @@ defmodule Horde.DynamicSupervisor do
       :distribution_strategy,
       :process_redistribution,
       :members,
-      :delta_crdt_options
+      :delta_crdt_options,
+      :tainted
     ]
 
     {sup_options, start_options} = Keyword.split(options, keys)
@@ -148,6 +150,7 @@ defmodule Horde.DynamicSupervisor do
     members = Keyword.get(options, :members, [])
     delta_crdt_options = Keyword.get(options, :delta_crdt_options, [])
     process_redistribution = Keyword.get(options, :process_redistribution, :passive)
+    tainted = Keyword.get(options, :tainted, false)
 
     distribution_strategy =
       Keyword.get(
@@ -165,7 +168,8 @@ defmodule Horde.DynamicSupervisor do
       distribution_strategy: distribution_strategy,
       members: members,
       delta_crdt_options: delta_crdt_options(delta_crdt_options),
-      process_redistribution: process_redistribution
+      process_redistribution: process_redistribution,
+      tainted: tainted
     }
 
     {:ok, flags}
@@ -196,7 +200,8 @@ defmodule Horde.DynamicSupervisor do
              extra_arguments: flags.extra_arguments,
              distribution_strategy: flags.distribution_strategy,
              process_redistribution: flags.process_redistribution,
-             members: members(flags.members, name)
+             members: members(flags.members, name),
+             tainted: flags.tainted
            ]},
           {Horde.ProcessesSupervisor,
            [

--- a/lib/horde/dynamic_supervisor_impl.ex
+++ b/lib/horde/dynamic_supervisor_impl.ex
@@ -2,7 +2,7 @@ defmodule Horde.DynamicSupervisor.Member do
   @moduledoc false
 
   @type t :: %Horde.DynamicSupervisor.Member{}
-  @type status :: :uninitialized | :alive | :shutting_down | :dead
+  @type status :: :uninitialized | :alive | :tainted | :shutting_down | :dead
   defstruct [:status, :name]
 end
 
@@ -23,6 +23,7 @@ defmodule Horde.DynamicSupervisorImpl do
             supervisor_ref_to_name: %{},
             name_to_supervisor_ref: %{},
             shutting_down: false,
+            tainted: false,
             supervisor_options: [],
             distribution_strategy: Horde.UniformDistribution
 
@@ -91,10 +92,20 @@ defmodule Horde.DynamicSupervisorImpl do
     }
   end
 
-  defp node_status(%{shutting_down: false}), do: :alive
+  # Have `shutting_down` take precedence over `tainted`.
   defp node_status(%{shutting_down: true}), do: :shutting_down
+  defp node_status(%{tainted: true}), do: :tainted
+  defp node_status(%{shutting_down: false}), do: :alive
 
   @doc false
+  def handle_call(:taint, _from, state) do
+    state =
+      %{state | tainted: true}
+      |> set_own_node_status()
+
+    {:reply, :ok, state}
+  end
+
   def handle_call(:horde_shutting_down, _f, state) do
     state =
       %{state | shutting_down: true}

--- a/lib/horde/dynamic_supervisor_impl.ex
+++ b/lib/horde/dynamic_supervisor_impl.ex
@@ -51,7 +51,8 @@ defmodule Horde.DynamicSupervisorImpl do
         supervisor_options: options,
         processes_by_id: new_table(:processes_by_id),
         process_pid_to_id: new_table(:process_pid_to_id),
-        name: name
+        name: name,
+        tainted: Keyword.get(options, :tainted, false)
       }
       |> Map.merge(Map.new(Keyword.take(options, [:distribution_strategy])))
 

--- a/lib/horde/dynamic_supervisor_impl.ex
+++ b/lib/horde/dynamic_supervisor_impl.ex
@@ -106,6 +106,14 @@ defmodule Horde.DynamicSupervisorImpl do
     {:reply, :ok, state}
   end
 
+  def handle_call(:untaint, _from, state) do
+    state =
+      %{state | tainted: false}
+      |> set_own_node_status()
+
+    {:reply, :ok, state}
+  end
+
   def handle_call(:horde_shutting_down, _f, state) do
     state =
       %{state | shutting_down: true}

--- a/test/dynamic_supervisor_taints_test.exs
+++ b/test/dynamic_supervisor_taints_test.exs
@@ -28,6 +28,7 @@ defmodule DynamicSupervisorTaintsTest do
         strategy: :one_for_one,
         delta_crdt_options: [sync_interval: 20]
       )
+
     Horde.Cluster.set_members(n1, [n1, n2, n3])
 
     # give the processes a couple ms to sync up
@@ -106,13 +107,54 @@ defmodule DynamicSupervisorTaintsTest do
     assert count2 + count3 == proc_count * 2
   end
 
-  # test "doesn't restart crashed process on a tainted node"
+  test "doesn't migrate processes to the tainted node after a node goes down", %{
+    n1: n1,
+    n2: n2,
+    n3: n3
+  } do
+    proc_count = 100
+
+    :ok = Horde.DynamicSupervisor.taint(n1)
+    Process.sleep(100)
+
+    for i <- 1..proc_count do
+      sup = Enum.random([n1, n2, n3])
+      child_spec = make_child_spec(i)
+
+      {:ok, _} = Horde.DynamicSupervisor.start_child(sup, child_spec)
+    end
+
+    eventually(fn ->
+      Horde.DynamicSupervisor.count_children(n1).active == proc_count
+    end)
+
+    count1 = count_local_children(n1) |> IO.inspect(label: "count1")
+    count2 = count_local_children(n2) |> IO.inspect(label: "count2")
+    count3 = count_local_children(n3) |> IO.inspect(label: "count3")
+
+    Process.flag(:trap_exit, true)
+    Horde.DynamicSupervisor.stop(n3, :shutdown)
+
+    eventually(
+      fn ->
+        count1 = count_local_children(n1)
+        count2 = count_local_children(n2)
+
+        assert count1 == 0
+        assert count2 == proc_count
+      end,
+      250,
+      100
+    )
+  end
+
   # test "doesn't start the process if only tainted nodes are available"
   # test "doesn't restart crashed process if only tainted nodes are available"
   # test "doesn't actively handoff processes when node becomes tainted"
   # test "doesn't handoff processes to tainted nodes during rebalancing"
   # test "processes are started on untainted node"
   # test "node that's untainted outside of the cluter joins the cluster as untainted"
+  # test taint on startup
 
   defp count_local_children(dynamic_sup) do
     proc_sup_name = :"#{dynamic_sup}.ProcessesSupervisor"
@@ -120,7 +162,7 @@ defmodule DynamicSupervisorTaintsTest do
   end
 
   defp make_child_spec(i) do
-      random_state = :rand.uniform(100_000_000)
-      %{id: i, start: {Agent, :start_link, [fn -> random_state end]}}
+    random_state = :rand.uniform(100_000_000)
+    %{id: i, start: {Agent, :start_link, [fn -> random_state end]}}
   end
 end

--- a/test/dynamic_supervisor_taints_test.exs
+++ b/test/dynamic_supervisor_taints_test.exs
@@ -1,0 +1,76 @@
+defmodule DynamicSupervisorTaintsTest do
+  require Logger
+  use ExUnit.Case
+
+  setup do
+    n1 = :horde_1
+    n2 = :horde_2
+    n3 = :horde_3
+
+    {:ok, _} =
+      Horde.DynamicSupervisor.start_link(
+        name: n1,
+        strategy: :one_for_one,
+        delta_crdt_options: [sync_interval: 20]
+      )
+
+    {:ok, _} =
+      Horde.DynamicSupervisor.start_link(
+        name: n2,
+        strategy: :one_for_one,
+        delta_crdt_options: [sync_interval: 20]
+      )
+
+    {:ok, _} =
+      Horde.DynamicSupervisor.start_link(
+        name: n3,
+        strategy: :one_for_one,
+        delta_crdt_options: [sync_interval: 20]
+      )
+
+    Horde.Cluster.set_members(n1, [n1, n2, n3])
+
+    # give the processes a couple ms to sync up
+    Process.sleep(100)
+
+    [n1: n1, n2: n2, n3: n3]
+  end
+
+  test "doesn't start a process on a tainted node", %{n1: n1, n2: n2, n3: n3} do
+    make_child = fn i ->
+      random_state = :rand.uniform(100_000_000)
+      %{id: i, start: {Agent, :start_link, [fn -> random_state end]}}
+    end
+
+    proc_count = 10_000
+
+    :ok = Horde.DynamicSupervisor.taint(n1)
+    Process.sleep(100)
+
+    for i <- 1..proc_count do
+      sup = Enum.random([n1, n2, n3])
+      child_spec = make_child.(i)
+
+      {:ok, _} = Horde.DynamicSupervisor.start_child(sup, child_spec)
+    end
+
+    count1 = count_local_children(n1)
+    count2 = count_local_children(n2)
+    count3 = count_local_children(n3)
+
+    assert count1 == 0
+    assert count2 + count3 == proc_count
+  end
+
+  # test "doesn't restart crashed process on a tainted node"
+  # test "doesn't start the process if only tainted nodes are available"
+  # test "doesn't restart crashed process if only tainted nodes are available"
+  # test "doesn't actively handoff processes when node becomes tainted"
+  # test "doesn't handoff processes to tainted nodes during rebalancing"
+  # test untainting
+
+  defp count_local_children(dynamic_sup) do
+    proc_sup_name = :"#{dynamic_sup}.ProcessesSupervisor"
+    Supervisor.count_children(proc_sup_name).active
+  end
+end

--- a/test/dynamic_supervisor_taints_test.exs
+++ b/test/dynamic_supervisor_taints_test.exs
@@ -1,6 +1,7 @@
 defmodule DynamicSupervisorTaintsTest do
   require Logger
   use ExUnit.Case
+  import Liveness
 
   setup do
     n1 = :horde_1
@@ -27,7 +28,6 @@ defmodule DynamicSupervisorTaintsTest do
         strategy: :one_for_one,
         delta_crdt_options: [sync_interval: 20]
       )
-
     Horde.Cluster.set_members(n1, [n1, n2, n3])
 
     # give the processes a couple ms to sync up
@@ -37,11 +37,6 @@ defmodule DynamicSupervisorTaintsTest do
   end
 
   test "doesn't start a process on a tainted node", %{n1: n1, n2: n2, n3: n3} do
-    make_child = fn i ->
-      random_state = :rand.uniform(100_000_000)
-      %{id: i, start: {Agent, :start_link, [fn -> random_state end]}}
-    end
-
     proc_count = 10_000
 
     :ok = Horde.DynamicSupervisor.taint(n1)
@@ -49,7 +44,7 @@ defmodule DynamicSupervisorTaintsTest do
 
     for i <- 1..proc_count do
       sup = Enum.random([n1, n2, n3])
-      child_spec = make_child.(i)
+      child_spec = make_child_spec(i)
 
       {:ok, _} = Horde.DynamicSupervisor.start_child(sup, child_spec)
     end
@@ -62,15 +57,70 @@ defmodule DynamicSupervisorTaintsTest do
     assert count2 + count3 == proc_count
   end
 
+  test "tainted node is still tainted when it re-joins the cluster", %{n1: n1, n2: n2, n3: n3} do
+    proc_count = 10_000
+
+    :ok = Horde.DynamicSupervisor.taint(n1)
+    Process.sleep(100)
+
+    for i <- 1..proc_count do
+      sup = Enum.random([n1, n2, n3])
+      child_spec = make_child_spec(i)
+
+      {:ok, _} = Horde.DynamicSupervisor.start_child(sup, child_spec)
+    end
+
+    count1 = count_local_children(n1)
+    count2 = count_local_children(n2)
+    count3 = count_local_children(n3)
+
+    assert count1 == 0
+    assert count2 + count3 == proc_count
+
+    # Remove node from the cluster.
+    :ok = Horde.Cluster.set_members(n1, [n1])
+
+    eventually(fn ->
+      Horde.DynamicSupervisor.count_children(n1).active == 0
+    end)
+
+    # Add the node back to the cluster.
+    :ok = Horde.Cluster.set_members(n1, [n1, n2, n3])
+
+    eventually(fn ->
+      Horde.DynamicSupervisor.count_children(n1).active == proc_count
+    end)
+
+    for i <- 1..proc_count do
+      sup = Enum.random([n1, n2, n3])
+      child_spec = make_child_spec(i)
+
+      {:ok, _} = Horde.DynamicSupervisor.start_child(sup, child_spec)
+    end
+
+    count1 = count_local_children(n1)
+    count2 = count_local_children(n2)
+    count3 = count_local_children(n3)
+
+    assert count1 == 0
+    assert count2 + count3 == proc_count * 2
+  end
+
   # test "doesn't restart crashed process on a tainted node"
   # test "doesn't start the process if only tainted nodes are available"
   # test "doesn't restart crashed process if only tainted nodes are available"
   # test "doesn't actively handoff processes when node becomes tainted"
   # test "doesn't handoff processes to tainted nodes during rebalancing"
-  # test untainting
+  # test "processes are started on untainted node"
+  # test "node that's untainted outside of the cluter joins the cluster as untainted"
 
   defp count_local_children(dynamic_sup) do
     proc_sup_name = :"#{dynamic_sup}.ProcessesSupervisor"
     Supervisor.count_children(proc_sup_name).active
+  end
+
+  defp make_child_spec(i) do
+      random_state = :rand.uniform(100_000_000)
+      %{id: i, start: {Agent, :start_link, [fn -> random_state end]}}
   end
 end

--- a/test/network_partition_test.exs
+++ b/test/network_partition_test.exs
@@ -73,6 +73,9 @@ defmodule NetworkPartitionTest do
 
     Process.sleep(100)
 
+    IO.inspect(:rpc.call(n1, DeltaCrdt, :read, [TestSup.Crdt]))
+    IO.inspect(:rpc.call(n2, DeltaCrdt, :read, [TestSup.Crdt]))
+
     Logger.info("stopping #{n2}")
     LocalCluster.stop_nodes([n2])
 

--- a/test/network_partition_test.exs
+++ b/test/network_partition_test.exs
@@ -73,9 +73,6 @@ defmodule NetworkPartitionTest do
 
     Process.sleep(100)
 
-    IO.inspect(:rpc.call(n1, DeltaCrdt, :read, [TestSup.Crdt]))
-    IO.inspect(:rpc.call(n2, DeltaCrdt, :read, [TestSup.Crdt]))
-
     Logger.info("stopping #{n2}")
     LocalCluster.stop_nodes([n2])
 


### PR DESCRIPTION
Member taints allow us to prevent starting new processes
under a specific supervisor in the cluster. This can be used
when draining processes from the supervisor and making sure 
that they are started elsewhere.
