### PR TITLE
Add a check in supervisor to verify if it's in tainted mode

### DIFF
--- a/lib/horde/dynamic_supervisor.ex
+++ b/lib/horde/dynamic_supervisor.ex
@@ -280,6 +280,11 @@ defmodule Horde.DynamicSupervisor do
   def untaint(supervisor), do: call(supervisor, :untaint)
 
   @doc """
+  Checks if the supervisor is currently in tainted mode.
+  """
+  def tainted?(supervisor), do: call(supervisor, :tainted?)
+
+  @doc """
   Waits for Horde.DynamicSupervisor to have quorum.
   """
   @spec wait_for_quorum(horde :: GenServer.server(), timeout :: timeout()) :: :ok

--- a/lib/horde/dynamic_supervisor_impl.ex
+++ b/lib/horde/dynamic_supervisor_impl.ex
@@ -115,6 +115,10 @@ defmodule Horde.DynamicSupervisorImpl do
     {:reply, :ok, state}
   end
 
+  def handle_call(:tainted?, from, state) do
+    {:reply, state.tainted, state}
+  end
+
   def handle_call(:horde_shutting_down, _f, state) do
     state =
       %{state | shutting_down: true}

--- a/lib/horde/dynamic_supervisor_impl.ex
+++ b/lib/horde/dynamic_supervisor_impl.ex
@@ -115,7 +115,7 @@ defmodule Horde.DynamicSupervisorImpl do
     {:reply, :ok, state}
   end
 
-  def handle_call(:tainted?, from, state) do
+  def handle_call(:tainted?, _from, state) do
     {:reply, state.tainted, state}
   end
 

--- a/test/dynamic_supervisor_taints_test.exs
+++ b/test/dynamic_supervisor_taints_test.exs
@@ -24,6 +24,9 @@ defmodule DynamicSupervisorTaintsTest do
 
     assert count1 == 0
     assert count2 + count3 == @proc_count
+    assert Horde.DynamicSupervisor.tainted?(n1)
+    refute Horde.DynamicSupervisor.tainted?(n2)
+    refute Horde.DynamicSupervisor.tainted?(n3)
   end
 
   test "tainted node is still tainted when it re-joins the cluster" do


### PR DESCRIPTION
I'm adding the auction processes draining on application shutdown.
I need some way of synchronizing tests to see that the tainting has been enabled. From now on, I can expect no new auctions to start on the node that started the shutdown sequence.