### PR TITLE
Monitor tainted supervisors

### DIFF
--- a/lib/horde/dynamic_supervisor_impl.ex
+++ b/lib/horde/dynamic_supervisor_impl.ex
@@ -664,6 +664,9 @@ defmodule Horde.DynamicSupervisorImpl do
         {name, %{status: :alive}} ->
           [name]
 
+        {name, %{status: :tainted}} ->
+          [name]
+
         _ ->
           []
       end)

--- a/test/dynamic_supervisor_taints_test.exs
+++ b/test/dynamic_supervisor_taints_test.exs
@@ -248,6 +248,46 @@ defmodule DynamicSupervisorTaintsTest do
     end
   end
 
+  test "a process is migrated from the tainted node that's being shutdown" do
+    # given
+    {n1, n2} = {:horde_1, :horde_2}
+    start_supervised!({Horde.DynamicSupervisor, Keyword.merge(@common_opts, [name: n1])})
+    child_spec = make_child_spec(1)
+
+    # process started on node 1, then tainted, then clustered with n2
+    {:ok, _} = Horde.DynamicSupervisor.start_child(n1, child_spec)
+    Horde.DynamicSupervisor.taint(n1)
+    start_supervised!({Horde.DynamicSupervisor, Keyword.merge(@common_opts, [name: n2])})
+    cluster([n1, n2])
+
+    # when
+    Process.flag(:trap_exit, true)
+    Horde.DynamicSupervisor.stop(n1, :shutdown)
+
+    # then
+    eventually(fn -> assert count_local_children(n2) == 1 end)
+  end
+
+  test "a process is migrated from the tainted node that's being killed" do
+    # given
+    {n1, n2} = {:horde_1, :horde_2}
+    start_supervised!({Horde.DynamicSupervisor, Keyword.merge(@common_opts, [name: n1])})
+    child_spec = make_child_spec(1)
+
+    # process started on node 1, then tainted, then clustered with n2
+    {:ok, _} = Horde.DynamicSupervisor.start_child(n1, child_spec)
+    Horde.DynamicSupervisor.taint(n1)
+    start_supervised!({Horde.DynamicSupervisor, Keyword.merge(@common_opts, [name: n2])})
+    cluster([n1, n2])
+
+    # when
+    Process.flag(:trap_exit, true)
+    Horde.DynamicSupervisor.stop(n1, :kill)
+
+    # then
+    eventually(fn -> assert count_local_children(n2) == 1 end)
+  end
+
   defp setup_cluster(size, opts) do
     members =
       for i <- 1..size do

--- a/test/dynamic_supervisor_taints_test.exs
+++ b/test/dynamic_supervisor_taints_test.exs
@@ -251,13 +251,13 @@ defmodule DynamicSupervisorTaintsTest do
   test "a process is migrated from the tainted node that's being shutdown" do
     # given
     {n1, n2} = {:horde_1, :horde_2}
-    start_supervised!({Horde.DynamicSupervisor, Keyword.merge(@common_opts, [name: n1])})
+    start_supervised!({Horde.DynamicSupervisor, Keyword.merge(@common_opts, name: n1)})
     child_spec = make_child_spec(1)
 
     # process started on node 1, then tainted, then clustered with n2
     {:ok, _} = Horde.DynamicSupervisor.start_child(n1, child_spec)
     Horde.DynamicSupervisor.taint(n1)
-    start_supervised!({Horde.DynamicSupervisor, Keyword.merge(@common_opts, [name: n2])})
+    start_supervised!({Horde.DynamicSupervisor, Keyword.merge(@common_opts, name: n2)})
     cluster([n1, n2])
 
     # when
@@ -271,13 +271,13 @@ defmodule DynamicSupervisorTaintsTest do
   test "a process is migrated from the tainted node that's being killed" do
     # given
     {n1, n2} = {:horde_1, :horde_2}
-    start_supervised!({Horde.DynamicSupervisor, Keyword.merge(@common_opts, [name: n1])})
+    start_supervised!({Horde.DynamicSupervisor, Keyword.merge(@common_opts, name: n1)})
     child_spec = make_child_spec(1)
 
     # process started on node 1, then tainted, then clustered with n2
     {:ok, _} = Horde.DynamicSupervisor.start_child(n1, child_spec)
     Horde.DynamicSupervisor.taint(n1)
-    start_supervised!({Horde.DynamicSupervisor, Keyword.merge(@common_opts, [name: n2])})
+    start_supervised!({Horde.DynamicSupervisor, Keyword.merge(@common_opts, name: n2)})
     cluster([n1, n2])
 
     # when


### PR DESCRIPTION
When a member joins the cluster, it does not monitor the tainted supervisor.
If that supervisor has some processes running, they might not be handed off when the supervisor exits (if it doesn't successfully relinquish children before shutting down).